### PR TITLE
Fix Discover avatar rendering

### DIFF
--- a/App/Features/Discover/DiscoverScreenModel.swift
+++ b/App/Features/Discover/DiscoverScreenModel.swift
@@ -38,6 +38,10 @@ struct DiscoverScreenModel: Equatable, Sendable {
   }
 
   struct Adventurer: Identifiable, Equatable, Sendable {
+    enum FallbackAvatarStyle: Equatable, Sendable {
+      case secondaryField
+    }
+
     let id: String
     let name: String
     let handle: String
@@ -95,8 +99,8 @@ struct DiscoverScreenModel: Equatable, Sendable {
       return "discover.avatar.fallback.\(id)"
     }
 
-    var fallbackAvatarBackgroundOpacity: Double {
-      0.28
+    var fallbackAvatarStyle: FallbackAvatarStyle {
+      .secondaryField
     }
   }
 

--- a/App/Features/Discover/DiscoverScreenModel.swift
+++ b/App/Features/Discover/DiscoverScreenModel.swift
@@ -86,6 +86,18 @@ struct DiscoverScreenModel: Equatable, Sendable {
     var displayHandle: String {
       handle.hasPrefix("@") ? handle : "@\(handle)"
     }
+
+    var avatarAccessibilityIdentifier: String {
+      if let avatarMediaID, avatarMediaID.isEmpty == false {
+        return "discover.avatar.remote.\(avatarMediaID)"
+      }
+
+      return "discover.avatar.fallback.\(id)"
+    }
+
+    var fallbackAvatarBackgroundOpacity: Double {
+      0.28
+    }
   }
 
   struct Adventure: Identifiable, Equatable, Sendable {

--- a/App/Features/Discover/DiscoverView.swift
+++ b/App/Features/Discover/DiscoverView.swift
@@ -415,6 +415,7 @@ private struct DiscoverSectionHeader: View {
 private struct DiscoverAdventurerCard: View {
   let adventurer: DiscoverScreenModel.Adventurer
   @Environment(\.discoverMediaSource) private var mediaSource
+  @Environment(\.discoverMediaLoader) private var mediaLoader
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -435,11 +436,10 @@ private struct DiscoverAdventurerCard: View {
           )
         }
 
-        HAAvatarView(
-          initials: adventurer.initials,
-          size: 48,
-          background: HATheme.Colors.primary.opacity(0.16),
-          foreground: HATheme.Colors.primary
+        DiscoverAvatarView(
+          adventurer: adventurer,
+          mediaLoader: mediaLoader,
+          size: 48
         )
         .overlay {
           Circle()
@@ -619,14 +619,14 @@ private struct DiscoverAdventureCard: View {
 
 private struct DiscoverPersonRow: View {
   let person: DiscoverScreenModel.Adventurer
+  @Environment(\.discoverMediaLoader) private var mediaLoader
 
   var body: some View {
     HStack(spacing: 14) {
-      HAAvatarView(
-        initials: person.initials,
-        size: 40,
-        background: HATheme.Colors.primary.opacity(0.14),
-        foreground: HATheme.Colors.primary
+      DiscoverAvatarView(
+        adventurer: person,
+        mediaLoader: mediaLoader,
+        size: 40
       )
 
       VStack(alignment: .leading, spacing: 3) {
@@ -670,6 +670,27 @@ private struct DiscoverPersonRow: View {
     }
 
     return person.displayHandle
+  }
+}
+
+private struct DiscoverAvatarView: View {
+  let adventurer: DiscoverScreenModel.Adventurer
+  let mediaLoader: any AdventureService
+  let size: CGFloat
+
+  var body: some View {
+    ProfileAvatarView(
+      initials: adventurer.initials,
+      mediaID: adventurer.avatarMediaID,
+      mediaLoader: mediaLoader,
+      size: size,
+      background: HATheme.Colors.primary.opacity(adventurer.fallbackAvatarBackgroundOpacity),
+      foreground: HATheme.Colors.primary,
+      borderColor: nil,
+      borderWidth: 0,
+      loadingTint: HATheme.Colors.primary
+    )
+    .accessibilityIdentifier(adventurer.avatarAccessibilityIdentifier)
   }
 }
 

--- a/App/Features/Discover/DiscoverView.swift
+++ b/App/Features/Discover/DiscoverView.swift
@@ -684,13 +684,27 @@ private struct DiscoverAvatarView: View {
       mediaID: adventurer.avatarMediaID,
       mediaLoader: mediaLoader,
       size: size,
-      background: HATheme.Colors.primary.opacity(adventurer.fallbackAvatarBackgroundOpacity),
-      foreground: HATheme.Colors.primary,
+      background: fallbackBackground,
+      foreground: fallbackForeground,
       borderColor: nil,
       borderWidth: 0,
       loadingTint: HATheme.Colors.primary
     )
     .accessibilityIdentifier(adventurer.avatarAccessibilityIdentifier)
+  }
+
+  private var fallbackBackground: Color {
+    switch adventurer.fallbackAvatarStyle {
+    case .secondaryField:
+      HATheme.Colors.secondary
+    }
+  }
+
+  private var fallbackForeground: Color {
+    switch adventurer.fallbackAvatarStyle {
+    case .secondaryField:
+      HATheme.Colors.foreground
+    }
   }
 }
 

--- a/App/Services/MockFixtures.swift
+++ b/App/Services/MockFixtures.swift
@@ -438,7 +438,8 @@ enum MockFixtures {
       adventureCount: 62,
       topCategories: ["Waterfall Hikes", "Canyon"],
       coverImageNames: ["hero-mountain", "hidden-canyon"],
-      avatarImageName: nil
+      avatarImageName: nil,
+      avatarMediaID: "hero-mountain"
     ),
     DiscoverScreenModel.Adventurer(
       id: "adventurer-theo-nakamura",

--- a/Tests/DiscoverScreenModelTests.swift
+++ b/Tests/DiscoverScreenModelTests.swift
@@ -19,7 +19,7 @@ final class DiscoverScreenModelTests: XCTestCase {
     XCTAssertEqual(adventurer.avatarAccessibilityIdentifier, "discover.avatar.remote.media-avatar")
   }
 
-  func testAdventurerAvatarFallbackUsesStrongerContrastTreatment() {
+  func testAdventurerAvatarFallbackUsesSecondaryBackgroundAndForegroundText() {
     let adventurer = DiscoverScreenModel.Adventurer(
       id: "adventurer-theo",
       name: "Theo Nakamura",
@@ -31,7 +31,7 @@ final class DiscoverScreenModelTests: XCTestCase {
       avatarImageName: nil
     )
 
-    XCTAssertEqual(adventurer.fallbackAvatarBackgroundOpacity, 0.28)
+    XCTAssertEqual(adventurer.fallbackAvatarStyle, .secondaryField)
   }
 
   func testSearchMatchesPeopleByNameAndHandleOnly() {

--- a/Tests/DiscoverScreenModelTests.swift
+++ b/Tests/DiscoverScreenModelTests.swift
@@ -2,6 +2,38 @@ import XCTest
 @testable import HiddenAdventures
 
 final class DiscoverScreenModelTests: XCTestCase {
+  func testAdventurerAvatarAccessibilityIdentifierUsesRemoteVariantWhenMediaExists() {
+    let adventurer = DiscoverScreenModel.Adventurer(
+      id: "adventurer-maya",
+      name: "Maya Reyes",
+      handle: "mayaexplores",
+      location: "Portland, OR",
+      adventureCount: 4,
+      topCategories: ["Trails"],
+      coverImageNames: [],
+      avatarImageName: nil,
+      coverMediaIDs: [],
+      avatarMediaID: "media-avatar"
+    )
+
+    XCTAssertEqual(adventurer.avatarAccessibilityIdentifier, "discover.avatar.remote.media-avatar")
+  }
+
+  func testAdventurerAvatarFallbackUsesStrongerContrastTreatment() {
+    let adventurer = DiscoverScreenModel.Adventurer(
+      id: "adventurer-theo",
+      name: "Theo Nakamura",
+      handle: "theo.outdoors",
+      location: "Bend, OR",
+      adventureCount: 8,
+      topCategories: ["Viewpoints"],
+      coverImageNames: [],
+      avatarImageName: nil
+    )
+
+    XCTAssertEqual(adventurer.fallbackAvatarBackgroundOpacity, 0.28)
+  }
+
   func testSearchMatchesPeopleByNameAndHandleOnly() {
     let model = MockFixtures.discoverScreenModel()
 

--- a/UITests/Screens/DiscoverScreenUITests.swift
+++ b/UITests/Screens/DiscoverScreenUITests.swift
@@ -150,6 +150,24 @@ final class DiscoverScreenUITests: HiddenAdventuresUITestCase {
     )
   }
 
+  func testDiscoverHomeShowsRemoteAndFallbackAvatars() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "discover-avatar-rendering")
+    let app = launchApp(startScreen: "discover")
+
+    assertExists(
+      app.images["discover.avatar.remote.hero-mountain"],
+      name: "discover-remote-avatar",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertExists(
+      app.staticTexts["discover.avatar.fallback.adventurer-theo-nakamura"],
+      name: "discover-fallback-avatar",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
+
   func testDiscoverEmptyFixtureRendersNoResultsState() throws {
     let screenshotDir = try preparedScreenshotDirectory(named: "discover-empty")
     let app = launchApp(


### PR DESCRIPTION
## Summary
- restore remote avatar rendering in Discover cards and rows when avatarMediaID is present
- strengthen the fallback avatar treatment when no avatar image is available
- add focused Discover unit and UI regressions for remote and fallback avatar states

Closes #3

## Validation
- xcodebuild -project HiddenAdventures.xcodeproj -scheme HiddenAdventures -destination platform=iOS\ Simulator,id=FF6D1245-7CFD-4A1B-B30B-FDC789531B5D -only-testing:HiddenAdventuresTests/DiscoverScreenModelTests test
- xcodebuild -project HiddenAdventures.xcodeproj -scheme HiddenAdventures -destination platform=iOS\ Simulator,id=FF6D1245-7CFD-4A1B-B30B-FDC789531B5D -only-testing:HiddenAdventuresUITests/DiscoverScreenUITests/testDiscoverHomeShowsRemoteAndFallbackAvatars test