### PR TITLE
Add favorites support across feed, detail, and profile

### DIFF
--- a/App/Features/AdventureDetail/AdventureDetailView.swift
+++ b/App/Features/AdventureDetail/AdventureDetailView.swift
@@ -22,6 +22,7 @@ struct AdventureDetailView: View {
   @State private var isLoading = false
   @State private var didFailToLoad = false
   @State private var isFavorited = false
+  @State private var isFavoriteMutationInFlight = false
   @State private var userRating = 0
   @State private var commentText = ""
 
@@ -106,6 +107,11 @@ struct AdventureDetailView: View {
       guard screenModel == nil, isLoading == false else { return }
       await loadScreen()
     }
+    .onReceive(NotificationCenter.default.publisher(for: FavoriteStateChange.notificationName)) { notification in
+      guard let change = FavoriteStateChange(notification: notification) else { return }
+      guard change.adventureID == MockFixtures.resolvedAdventureID(for: adventureID) else { return }
+      isFavorited = change.isFavorited
+    }
   }
 
   private var hero: some View {
@@ -181,12 +187,13 @@ struct AdventureDetailView: View {
         .opacity(usesFixturePreview ? 1 : 0.7)
         .accessibilityIdentifier("detail.share")
 
-        Button(action: { isFavorited.toggle() }) {
+        Button(action: toggleFavorite) {
           FavoriteNavigationButton(isFavorited: isFavorited)
         }
         .buttonStyle(.plain)
-        .disabled(usesFixturePreview == false)
-        .opacity(usesFixturePreview ? 1 : 0.7)
+        .disabled(isFavoriteMutationInFlight || screenModel == nil)
+        .accessibilityLabel(isFavorited ? "Remove favorite" : "Add favorite")
+        .accessibilityValue(isFavorited ? "favorited" : "not favorited")
         .accessibilityIdentifier("detail.favorite")
       }
     }
@@ -515,6 +522,9 @@ struct AdventureDetailView: View {
     defer { isLoading = false }
 
     if runtimeMode == .fixturePreview {
+      if let detail = try? await adventureService.getAdventure(id: adventureID).item {
+        isFavorited = detail.isFavorited
+      }
       screenModel = MockFixtures.adventureDetailScreenModel(
         for: adventureID,
         variant: fixtureVariant
@@ -524,6 +534,7 @@ struct AdventureDetailView: View {
 
     do {
       let detail = try await adventureService.getAdventure(id: adventureID).item
+      isFavorited = detail.isFavorited
       async let authorProfileTask: ProfileDetail? = loadAuthorProfile(handle: detail.author.handle)
       async let mediaTask: [String] = loadMediaIDs(for: detail)
 
@@ -541,6 +552,27 @@ struct AdventureDetailView: View {
       )
     } catch {
       didFailToLoad = true
+    }
+  }
+
+  private func toggleFavorite() {
+    let targetState = !isFavorited
+    let previousState = isFavorited
+    isFavorited = targetState
+    isFavoriteMutationInFlight = true
+
+    Task {
+      do {
+        if targetState {
+          try await adventureService.favoriteAdventure(id: adventureID)
+        } else {
+          try await adventureService.unfavoriteAdventure(id: adventureID)
+        }
+      } catch {
+        isFavorited = previousState
+      }
+
+      isFavoriteMutationInFlight = false
     }
   }
 
@@ -602,7 +634,7 @@ private struct FavoriteNavigationButton: View {
   let isFavorited: Bool
 
   var body: some View {
-    Image(systemName: "bookmark.fill")
+    Image(systemName: isFavorited ? "bookmark.fill" : "bookmark")
       .font(.system(size: 16, weight: .semibold))
       .foregroundStyle(isFavorited ? .white : HATheme.Colors.foreground)
       .frame(width: 40, height: 40)

--- a/App/Features/Explore/FeedView.swift
+++ b/App/Features/Explore/FeedView.swift
@@ -6,27 +6,17 @@ struct FeedView: View {
   let adventureService: AdventureService
   let runtimeMode: AppRuntimeMode
   let onOpenDetail: (String) -> Void
-
-  private func accessibilityAdventureID(_ id: String) -> String {
-    runtimeMode == .fixturePreview ? MockFixtures.uiTestAdventureID(for: id) : id
-  }
-
   var body: some View {
     ScrollView {
       LazyVStack(spacing: 16) {
         ForEach(items) { adventure in
-          Button {
-            onOpenDetail(adventure.id)
-          } label: {
-            FeedCardView(
-              adventure: adventure,
-              scope: scope,
-              adventureService: adventureService,
-              runtimeMode: runtimeMode
-            )
-          }
-          .buttonStyle(.plain)
-          .accessibilityIdentifier("feed.card.\(accessibilityAdventureID(adventure.id))")
+          FeedCardView(
+            adventure: adventure,
+            scope: scope,
+            adventureService: adventureService,
+            runtimeMode: runtimeMode,
+            onOpenDetail: onOpenDetail
+          )
         }
       }
       .padding(.horizontal, 20)
@@ -53,124 +43,195 @@ private struct FeedCardView: View {
   let scope: FeedScope?
   let adventureService: AdventureService
   let runtimeMode: AppRuntimeMode
+  let onOpenDetail: (String) -> Void
+
+  @State private var visibleAdventure: AdventureCard
+  @State private var isFavoriteMutationInFlight = false
+
+  init(
+    adventure: AdventureCard,
+    scope: FeedScope?,
+    adventureService: AdventureService,
+    runtimeMode: AppRuntimeMode,
+    onOpenDetail: @escaping (String) -> Void
+  ) {
+    self.adventure = adventure
+    self.scope = scope
+    self.adventureService = adventureService
+    self.runtimeMode = runtimeMode
+    self.onOpenDetail = onOpenDetail
+    _visibleAdventure = State(initialValue: adventure)
+  }
 
   private var accessibilityAdventureID: String {
-    runtimeMode == .fixturePreview ? MockFixtures.uiTestAdventureID(for: adventure.id) : adventure.id
+    runtimeMode == .fixturePreview ? MockFixtures.uiTestAdventureID(for: visibleAdventure.id) : visibleAdventure.id
   }
 
   private var mediaSource: HAMediaSource {
     if runtimeMode == .fixturePreview {
       return .fixture(
         AdventurePresentation.imageNames(
-          for: adventure.id,
+          for: visibleAdventure.id,
           runtimeMode: runtimeMode
         )
       )
     }
 
     return .remote(
-      adventure.primaryMedia.map(\.id).map { [$0] } ?? [],
+      visibleAdventure.primaryMedia.map(\.id).map { [$0] } ?? [],
       adventureService
     )
   }
 
   var body: some View {
     ZStack {
-      ZStack(alignment: .bottomLeading) {
-        HAMediaCarouselOrPlaceholder(
-          source: mediaSource,
-          aspectRatio: 4 / 3,
-          cornerRadius: 16,
-          dotsInside: true,
-          title: adventure.title
-        )
-        .overlay {
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(
-              LinearGradient(
-                colors: [.clear, .black.opacity(0.10), .black.opacity(0.65)],
-                startPoint: .top,
-                endPoint: .bottom
-              )
-            )
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-
-        VStack(alignment: .leading, spacing: 8) {
-          Text(adventure.title)
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(.white)
-            .multilineTextAlignment(.leading)
-            .lineSpacing(1)
-            .accessibilityIdentifier("feed.card.title.\(accessibilityAdventureID)")
-
-          HStack(alignment: .center) {
-            HStack(spacing: 4) {
-              Image(systemName: "mappin")
-                .font(.system(size: 12, weight: .medium))
-              Text(adventure.placeLabel ?? "Hidden location")
-                .lineLimit(1)
-            }
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(.white.opacity(0.82))
-            .accessibilityIdentifier("feed.card.location.\(accessibilityAdventureID)")
-
-            Spacer(minLength: 8)
-
-            HStack(spacing: 12) {
-              if scope != nil, let distanceMiles = adventure.distanceMiles {
-                HStack(spacing: 4) {
-                  Image(systemName: "location.north.line")
-                  Text(String(format: "%.1f mi", distanceMiles))
-                }
-              }
-
-              HStack(spacing: 4) {
-                Image(systemName: "star.fill")
-                Text(String(format: "%.1f", adventure.stats.averageRating))
-              }
-              HStack(spacing: 4) {
-                Image(systemName: "heart")
-                Text(adventure.stats.favoriteCount.formatted())
-              }
-            }
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(.white.opacity(0.86))
-          }
-        }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 28)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+      Button {
+        onOpenDetail(visibleAdventure.id)
+      } label: {
+        cardContent
       }
+      .buttonStyle(.plain)
+      .accessibilityIdentifier("feed.card.\(accessibilityAdventureID)")
 
       VStack {
         HStack {
-          if let categoryLabel = adventure.categoryLabel ?? adventure.categorySlug?.displayTitle {
-            Text(categoryLabel)
-              .font(.system(size: 11, weight: .medium))
-              .foregroundStyle(HATheme.Colors.foreground)
-              .padding(.horizontal, 10)
-              .padding(.vertical, 4)
-              .background(.white.opacity(0.92))
-              .clipShape(Capsule(style: .continuous))
-              .accessibilityIdentifier("feed.card.category.\(accessibilityAdventureID)")
-          }
+          categoryBadge
 
           Spacer()
 
-          Button(action: {}) {
-            Image(systemName: "bookmark")
+          Button(action: toggleFavorite) {
+            Image(systemName: visibleAdventure.isFavorited ? "bookmark.fill" : "bookmark")
               .font(.system(size: 14, weight: .medium))
-              .foregroundStyle(HATheme.Colors.foreground)
+              .foregroundStyle(visibleAdventure.isFavorited ? .white : HATheme.Colors.foreground)
               .frame(width: 32, height: 32)
-              .background(.white.opacity(0.92))
+              .background(visibleAdventure.isFavorited ? HATheme.Colors.primary : .white.opacity(0.92))
               .clipShape(Circle())
           }
           .buttonStyle(.plain)
+          .disabled(isFavoriteMutationInFlight)
+          .accessibilityLabel(visibleAdventure.isFavorited ? "Remove favorite" : "Add favorite")
+          .accessibilityValue(visibleAdventure.isFavorited ? "favorited" : "not favorited")
+          .accessibilityIdentifier("feed.card.favorite.\(accessibilityAdventureID)")
         }
         Spacer()
       }
       .padding(12)
+    }
+    .onChange(of: adventure) { _, newValue in
+      visibleAdventure = newValue
+    }
+    .onReceive(NotificationCenter.default.publisher(for: FavoriteStateChange.notificationName)) { notification in
+      guard let change = FavoriteStateChange(notification: notification) else { return }
+      guard change.adventureID == visibleAdventure.id else { return }
+      visibleAdventure = visibleAdventure.applyingFavoriteState(change.isFavorited)
+    }
+  }
+
+  private var cardContent: some View {
+    ZStack(alignment: .bottomLeading) {
+      HAMediaCarouselOrPlaceholder(
+        source: mediaSource,
+        aspectRatio: 4 / 3,
+        cornerRadius: 16,
+        dotsInside: true,
+        title: visibleAdventure.title
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: [.clear, .black.opacity(0.10), .black.opacity(0.65)],
+              startPoint: .top,
+              endPoint: .bottom
+            )
+          )
+      }
+      .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text(visibleAdventure.title)
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundStyle(.white)
+          .multilineTextAlignment(.leading)
+          .lineSpacing(1)
+          .accessibilityIdentifier("feed.card.title.\(accessibilityAdventureID)")
+
+        HStack(alignment: .center) {
+          HStack(spacing: 4) {
+            Image(systemName: "mappin")
+              .font(.system(size: 12, weight: .medium))
+            Text(visibleAdventure.placeLabel ?? "Hidden location")
+              .lineLimit(1)
+          }
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.white.opacity(0.82))
+          .accessibilityIdentifier("feed.card.location.\(accessibilityAdventureID)")
+
+          Spacer(minLength: 8)
+
+          statsRow
+        }
+      }
+      .padding(.horizontal, 16)
+      .padding(.bottom, 28)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+    }
+  }
+
+  @ViewBuilder
+  private var categoryBadge: some View {
+    if let categoryLabel = visibleAdventure.categoryLabel ?? visibleAdventure.categorySlug?.displayTitle {
+      Text(categoryLabel)
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(HATheme.Colors.foreground)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(.white.opacity(0.92))
+        .clipShape(Capsule(style: .continuous))
+        .accessibilityIdentifier("feed.card.category.\(accessibilityAdventureID)")
+    }
+  }
+
+  private var statsRow: some View {
+    HStack(spacing: 12) {
+      if scope != nil, let distanceMiles = visibleAdventure.distanceMiles {
+        HStack(spacing: 4) {
+          Image(systemName: "location.north.line")
+          Text(String(format: "%.1f mi", distanceMiles))
+        }
+      }
+
+      HStack(spacing: 4) {
+        Image(systemName: "star.fill")
+        Text(String(format: "%.1f", visibleAdventure.stats.averageRating))
+      }
+      HStack(spacing: 4) {
+        Image(systemName: "heart")
+        Text(visibleAdventure.stats.favoriteCount.formatted())
+      }
+    }
+    .font(.system(size: 13, weight: .medium))
+    .foregroundStyle(.white.opacity(0.86))
+  }
+
+  private func toggleFavorite() {
+    let targetState = !visibleAdventure.isFavorited
+    let previousState = visibleAdventure
+    visibleAdventure = visibleAdventure.applyingFavoriteState(targetState)
+    isFavoriteMutationInFlight = true
+
+    Task {
+      do {
+        if targetState {
+          try await adventureService.favoriteAdventure(id: visibleAdventure.id)
+        } else {
+          try await adventureService.unfavoriteAdventure(id: visibleAdventure.id)
+        }
+      } catch {
+        visibleAdventure = previousState
+      }
+
+      isFavoriteMutationInFlight = false
     }
   }
 }

--- a/App/Features/Profile/ProfileView.swift
+++ b/App/Features/Profile/ProfileView.swift
@@ -21,10 +21,13 @@ struct ProfileView: View {
   let onLogout: () -> Void
 
   @State private var response: ProfileResponse?
+  @State private var favoritesResponse: ProfileFavoritesResponse?
   @State private var isLoading = true
   @State private var errorMessage: String?
   @State private var sidekickSummaryItems: [SidekickListItem] = []
   @State private var isLoadingSidekickSummary = false
+  @State private var isLoadingFavorites = false
+  @State private var selectedCollection: ProfileAdventureCollection = .shared
 
   var body: some View {
     ZStack {
@@ -40,7 +43,16 @@ struct ProfileView: View {
         ScrollView {
           VStack(spacing: 0) {
             header(profile: response.profile)
-            authoredSection(adventures: response.adventures)
+            if isViewingOwnProfile {
+              collectionSegment
+            }
+
+            switch selectedCollection {
+            case .shared:
+              authoredSection(adventures: response.adventures)
+            case .favorites:
+              favoritesSection(adventures: favoritesResponse?.items ?? [])
+            }
           }
           .padding(.bottom, 24)
         }
@@ -51,13 +63,22 @@ struct ProfileView: View {
       guard response == nil, errorMessage == nil else { return }
       await loadProfile()
     }
+    .onReceive(NotificationCenter.default.publisher(for: FavoriteStateChange.notificationName)) { notification in
+      guard let change = FavoriteStateChange(notification: notification) else { return }
+      guard isViewingOwnProfile else { return }
+      handleFavoriteStateChange(change)
+    }
     .toolbar(.hidden, for: .navigationBar)
   }
 
-  private var showsSidekicksCard: Bool {
+  private var isViewingOwnProfile: Bool {
     guard let viewerHandle else { return false }
     guard let response else { return false }
     return response.profile.handle == viewerHandle
+  }
+
+  private var showsSidekicksCard: Bool {
+    isViewingOwnProfile
   }
 
   private var showsBackButton: Bool {
@@ -296,6 +317,41 @@ struct ProfileView: View {
     return "\(sidekickSummaryItems.count) Sidekicks"
   }
 
+  private var collectionSegment: some View {
+    HStack(spacing: 8) {
+      collectionSegmentButton(.shared)
+      collectionSegmentButton(.favorites)
+    }
+    .padding(.horizontal, 24)
+    .padding(.top, Layout.contentSectionSpacing)
+  }
+
+  private func collectionSegmentButton(_ collection: ProfileAdventureCollection) -> some View {
+    Button {
+      selectedCollection = collection
+      if collection == .favorites, favoritesResponse == nil {
+        Task {
+          await loadFavoriteAdventures()
+        }
+      }
+    } label: {
+      Text(collection.title)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(selectedCollection == collection ? .white : HATheme.Colors.foreground)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 11)
+        .background(selectedCollection == collection ? HATheme.Colors.primary : HATheme.Colors.card)
+        .overlay {
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .stroke(HATheme.Colors.border.opacity(0.7), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .accessibilityValue(selectedCollection == collection ? "selected" : "not selected")
+    .accessibilityIdentifier("profile.segment.\(collection.accessibilityKey)")
+  }
+
   private func authoredSection(adventures: [AdventureCard]) -> some View {
     VStack(alignment: .leading, spacing: 16) {
       Text("Shared adventures")
@@ -312,6 +368,59 @@ struct ProfileView: View {
         runtimeMode: runtimeMode,
         onOpenDetail: onOpenDetail
       )
+    }
+  }
+
+  private func favoritesSection(adventures: [AdventureCard]) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("Favorite adventures")
+        .font(.system(size: 20, weight: .semibold))
+        .foregroundStyle(HATheme.Colors.foreground)
+        .padding(.top, Layout.contentSectionSpacing)
+        .padding(.horizontal, 24)
+        .accessibilityIdentifier("profile.favoriteAdventuresHeading")
+
+      if isLoadingFavorites {
+        ProgressView()
+          .tint(HATheme.Colors.primary)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 24)
+      } else if adventures.isEmpty {
+        VStack(spacing: 10) {
+          Image(systemName: "bookmark")
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(HATheme.Colors.primary)
+
+          Text("No favorites yet")
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundStyle(HATheme.Colors.foreground)
+
+          Text("Save adventures from the feed or detail screen, and they will show up here.")
+            .font(HATheme.Typography.body)
+            .foregroundStyle(HATheme.Colors.mutedForeground)
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 28)
+        .background(HATheme.Colors.card)
+        .overlay {
+          RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .stroke(HATheme.Colors.border, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .padding(.horizontal, 24)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("profile.favorites.empty")
+      } else {
+        FeedView(
+          items: adventures,
+          scope: nil,
+          adventureService: adventureService,
+          runtimeMode: runtimeMode,
+          onOpenDetail: onOpenDetail
+        )
+      }
     }
   }
 
@@ -393,6 +502,7 @@ struct ProfileView: View {
 
       if showsSidekicksCard {
         await loadSidekickSummary()
+        await loadFavoriteAdventures()
       }
       return
     } catch {
@@ -419,6 +529,47 @@ struct ProfileView: View {
     } catch {
       sidekickSummaryItems = []
     }
+  }
+
+  @MainActor
+  private func loadFavoriteAdventures() async {
+    guard isViewingOwnProfile, let handle = response?.profile.handle else {
+      favoritesResponse = nil
+      isLoadingFavorites = false
+      return
+    }
+
+    isLoadingFavorites = true
+    defer { isLoadingFavorites = false }
+
+    do {
+      favoritesResponse = try await profileService.getProfileFavorites(handle: handle, limit: 20, offset: 0)
+    } catch {
+      favoritesResponse = ProfileFavoritesResponse(
+        items: [],
+        paging: Paging(limit: 20, offset: 0, returned: 0)
+      )
+    }
+  }
+
+  private func handleFavoriteStateChange(_ change: FavoriteStateChange) {
+    if change.isFavorited {
+      Task {
+        await loadFavoriteAdventures()
+      }
+      return
+    }
+
+    guard let favoritesResponse else { return }
+    let items = favoritesResponse.items.filter { $0.id != change.adventureID }
+    self.favoritesResponse = ProfileFavoritesResponse(
+      items: items,
+      paging: Paging(
+        limit: favoritesResponse.paging.limit,
+        offset: favoritesResponse.paging.offset,
+        returned: items.count
+      )
+    )
   }
 
   private func initials(for profile: ProfileDetail) -> String {
@@ -468,6 +619,29 @@ struct ProfileView: View {
       return region
     default:
       return nil
+    }
+  }
+}
+
+private enum ProfileAdventureCollection {
+  case shared
+  case favorites
+
+  var title: String {
+    switch self {
+    case .shared:
+      return "Shared"
+    case .favorites:
+      return "Favorites"
+    }
+  }
+
+  var accessibilityKey: String {
+    switch self {
+    case .shared:
+      return "shared"
+    case .favorites:
+      return "favorites"
     }
   }
 }

--- a/App/HiddenAdventuresApp.swift
+++ b/App/HiddenAdventuresApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct HiddenAdventuresApp: App {
   private static let logger = AppLogger.logger(category: "app.startup")
   private let runtime = AppRuntime()
+  private let favoriteFixtureStore = FavoriteFixtureStore.fromEnvironment()
   private let authState: AuthStateStore
 
   init() {
@@ -49,7 +50,7 @@ struct HiddenAdventuresApp: App {
 
   private var adventureService: AdventureService {
     if runtime.usesFixturePreview {
-      return FixtureAdventureService()
+      return FixtureAdventureService(favoriteStore: favoriteFixtureStore)
     }
 
     return RemoteAdventureService(client: apiClient)
@@ -57,7 +58,7 @@ struct HiddenAdventuresApp: App {
 
   private var profileService: ProfileService {
     if runtime.usesFixturePreview {
-      return FixtureProfileService()
+      return FixtureProfileService(favoriteStore: favoriteFixtureStore)
     }
 
     return RemoteProfileService(client: apiClient)

--- a/App/Infrastructure/APIClient.swift
+++ b/App/Infrastructure/APIClient.swift
@@ -93,6 +93,19 @@ struct APIClient {
     )
   }
 
+  func postNoContent(
+    pathComponents: [String],
+    requiresAuth: Bool = false
+  ) async throws {
+    _ = try await performRequest(
+      pathComponents: pathComponents,
+      method: "POST",
+      queryItems: [],
+      requiresAuth: requiresAuth,
+      body: Optional<Data>.none
+    )
+  }
+
   func put<Body: Encodable, Response: Decodable>(
     pathComponents: [String],
     body: Body,
@@ -113,6 +126,19 @@ struct APIClient {
     requiresAuth: Bool = false
   ) async throws -> Response {
     try await send(
+      pathComponents: pathComponents,
+      method: "DELETE",
+      queryItems: [],
+      requiresAuth: requiresAuth,
+      body: Optional<Data>.none
+    )
+  }
+
+  func deleteNoContent(
+    pathComponents: [String],
+    requiresAuth: Bool = false
+  ) async throws {
+    _ = try await performRequest(
       pathComponents: pathComponents,
       method: "DELETE",
       queryItems: [],

--- a/App/Models/DomainModels.swift
+++ b/App/Models/DomainModels.swift
@@ -139,6 +139,25 @@ struct AdventureStats: Codable, Hashable, Sendable {
   let commentCount: Int
   let ratingCount: Int
   let averageRating: Double
+
+  func favoriteCountAdjusted(isFavorited: Bool, wasFavorited: Bool) -> AdventureStats {
+    let delta: Int
+    switch (wasFavorited, isFavorited) {
+    case (false, true):
+      delta = 1
+    case (true, false):
+      delta = -1
+    default:
+      delta = 0
+    }
+
+    return AdventureStats(
+      favoriteCount: max(0, favoriteCount + delta),
+      commentCount: commentCount,
+      ratingCount: ratingCount,
+      averageRating: averageRating
+    )
+  }
 }
 
 struct AdventureCard: Codable, Identifiable, Hashable, Sendable {
@@ -156,6 +175,61 @@ struct AdventureCard: Codable, Identifiable, Hashable, Sendable {
   let primaryMedia: MediaReference?
   let stats: AdventureStats
   let distanceMiles: Double?
+  let isFavorited: Bool
+
+  init(
+    id: String,
+    title: String,
+    description: String?,
+    categorySlug: Category?,
+    categoryLabel: String?,
+    visibility: Visibility,
+    createdAt: String,
+    publishedAt: String?,
+    location: AdventureLocation?,
+    placeLabel: String?,
+    author: AdventureAuthor,
+    primaryMedia: MediaReference?,
+    stats: AdventureStats,
+    distanceMiles: Double?,
+    isFavorited: Bool = false
+  ) {
+    self.id = id
+    self.title = title
+    self.description = description
+    self.categorySlug = categorySlug
+    self.categoryLabel = categoryLabel
+    self.visibility = visibility
+    self.createdAt = createdAt
+    self.publishedAt = publishedAt
+    self.location = location
+    self.placeLabel = placeLabel
+    self.author = author
+    self.primaryMedia = primaryMedia
+    self.stats = stats
+    self.distanceMiles = distanceMiles
+    self.isFavorited = isFavorited
+  }
+
+  func applyingFavoriteState(_ isFavorited: Bool) -> AdventureCard {
+    AdventureCard(
+      id: id,
+      title: title,
+      description: description,
+      categorySlug: categorySlug,
+      categoryLabel: categoryLabel,
+      visibility: visibility,
+      createdAt: createdAt,
+      publishedAt: publishedAt,
+      location: location,
+      placeLabel: placeLabel,
+      author: author,
+      primaryMedia: primaryMedia,
+      stats: stats.favoriteCountAdjusted(isFavorited: isFavorited, wasFavorited: self.isFavorited),
+      distanceMiles: distanceMiles,
+      isFavorited: isFavorited
+    )
+  }
 }
 
 struct AdventureDetail: Codable, Identifiable, Hashable, Sendable {
@@ -173,6 +247,61 @@ struct AdventureDetail: Codable, Identifiable, Hashable, Sendable {
   let stats: AdventureStats
   let placeLabel: String?
   let updatedAt: String
+  let isFavorited: Bool
+
+  init(
+    id: String,
+    title: String,
+    description: String?,
+    categorySlug: Category?,
+    categoryLabel: String?,
+    visibility: Visibility,
+    createdAt: String,
+    publishedAt: String?,
+    location: AdventureLocation?,
+    author: AdventureAuthor,
+    primaryMedia: MediaReference?,
+    stats: AdventureStats,
+    placeLabel: String?,
+    updatedAt: String,
+    isFavorited: Bool = false
+  ) {
+    self.id = id
+    self.title = title
+    self.description = description
+    self.categorySlug = categorySlug
+    self.categoryLabel = categoryLabel
+    self.visibility = visibility
+    self.createdAt = createdAt
+    self.publishedAt = publishedAt
+    self.location = location
+    self.author = author
+    self.primaryMedia = primaryMedia
+    self.stats = stats
+    self.placeLabel = placeLabel
+    self.updatedAt = updatedAt
+    self.isFavorited = isFavorited
+  }
+
+  func applyingFavoriteState(_ isFavorited: Bool) -> AdventureDetail {
+    AdventureDetail(
+      id: id,
+      title: title,
+      description: description,
+      categorySlug: categorySlug,
+      categoryLabel: categoryLabel,
+      visibility: visibility,
+      createdAt: createdAt,
+      publishedAt: publishedAt,
+      location: location,
+      author: author,
+      primaryMedia: primaryMedia,
+      stats: stats.favoriteCountAdjusted(isFavorited: isFavorited, wasFavorited: self.isFavorited),
+      placeLabel: placeLabel,
+      updatedAt: updatedAt,
+      isFavorited: isFavorited
+    )
+  }
 }
 
 struct ProfileDetail: Codable, Identifiable, Hashable, Sendable {
@@ -230,6 +359,11 @@ struct AdventureMediaListResponse: Codable, Sendable {
 struct ProfileResponse: Codable, Sendable {
   let profile: ProfileDetail
   let adventures: [AdventureCard]
+  let paging: Paging
+}
+
+struct ProfileFavoritesResponse: Codable, Sendable {
+  let items: [AdventureCard]
   let paging: Paging
 }
 

--- a/App/Services/AdventureService.swift
+++ b/App/Services/AdventureService.swift
@@ -95,14 +95,106 @@ protocol AdventureService {
   func createAdventure(
     request: CreateAdventureRequest
   ) async throws -> CreateAdventureResponse
+
+  func favoriteAdventure(id: String) async throws
+  func unfavoriteAdventure(id: String) async throws
+}
+
+struct FavoriteStateChange: Sendable {
+  static let notificationName = Notification.Name("HiddenAdventuresFavoriteStateDidChange")
+  static let adventureIDKey = "adventureID"
+  static let isFavoritedKey = "isFavorited"
+
+  let adventureID: String
+  let isFavorited: Bool
+
+  init?(notification: Notification) {
+    guard
+      let adventureID = notification.userInfo?[Self.adventureIDKey] as? String,
+      let isFavorited = notification.userInfo?[Self.isFavoritedKey] as? Bool
+    else {
+      return nil
+    }
+
+    self.adventureID = adventureID
+    self.isFavorited = isFavorited
+  }
+
+  static func post(adventureID: String, isFavorited: Bool) {
+    NotificationCenter.default.post(
+      name: notificationName,
+      object: nil,
+      userInfo: [
+        adventureIDKey: adventureID,
+        isFavoritedKey: isFavorited
+      ]
+    )
+  }
+}
+
+actor FavoriteFixtureStore {
+  private var storedFavoriteIDs: Set<String>
+
+  init(initialFavoriteIDs: Set<String>) {
+    self.storedFavoriteIDs = initialFavoriteIDs
+  }
+
+  init(initialFavoriteIDs: [String]) {
+    self.storedFavoriteIDs = Set(initialFavoriteIDs)
+  }
+
+  static func fromEnvironment(_ environment: [String: String] = ProcessInfo.processInfo.environment) -> FavoriteFixtureStore {
+    switch environment["UITEST_PROFILE_FAVORITES"]?.lowercased() {
+    case "empty":
+      return FavoriteFixtureStore(initialFavoriteIDs: [])
+    case "populated":
+      return FavoriteFixtureStore(initialFavoriteIDs: [MockFixtures.bluePoolID])
+    default:
+      return FavoriteFixtureStore(initialFavoriteIDs: [MockFixtures.eagleID])
+    }
+  }
+
+  func favoriteIDs() -> Set<String> {
+    storedFavoriteIDs
+  }
+
+  func contains(_ id: String) -> Bool {
+    storedFavoriteIDs.contains(id)
+  }
+
+  func favorite(id: String) throws {
+    guard MockFixtures.adventureDetails[id] != nil else {
+      throw FixtureServiceError.notFound
+    }
+
+    storedFavoriteIDs.insert(id)
+    FavoriteStateChange.post(adventureID: id, isFavorited: true)
+  }
+
+  func unfavorite(id: String) throws {
+    guard MockFixtures.adventureDetails[id] != nil else {
+      throw FixtureServiceError.notFound
+    }
+
+    storedFavoriteIDs.remove(id)
+    FavoriteStateChange.post(adventureID: id, isFavorited: false)
+  }
 }
 
 struct FixtureAdventureService: AdventureService {
+  let favoriteStore: FavoriteFixtureStore
+
+  init(favoriteStore: FavoriteFixtureStore = FavoriteFixtureStore.fromEnvironment()) {
+    self.favoriteStore = favoriteStore
+  }
+
   func listFeed(
     query: FeedQuery
   ) async throws -> FeedResponse {
+    let favoriteIDs = await favoriteStore.favoriteIDs()
     let filteredItems = MockFixtures.feedItems
       .compactMap { item -> AdventureCard? in
+        let item = item.applyingFavoriteState(favoriteIDs.contains(item.id))
         guard
           let scope = query.scope,
           let location = item.location
@@ -135,7 +227,8 @@ struct FixtureAdventureService: AdventureService {
           author: item.author,
           primaryMedia: item.primaryMedia,
           stats: item.stats,
-          distanceMiles: Double(round(distanceMiles * 10) / 10)
+          distanceMiles: Double(round(distanceMiles * 10) / 10),
+          isFavorited: item.isFavorited
         )
       }
 
@@ -173,7 +266,9 @@ struct FixtureAdventureService: AdventureService {
   ) async throws -> AdventureDetailResponse {
     let resolvedID = MockFixtures.resolvedAdventureID(for: id)
     if let detail = MockFixtures.adventureDetails[resolvedID] {
-      return AdventureDetailResponse(item: detail)
+      return AdventureDetailResponse(
+        item: detail.applyingFavoriteState(await favoriteStore.contains(resolvedID))
+      )
     }
 
     throw FixtureServiceError.notFound
@@ -209,6 +304,14 @@ struct FixtureAdventureService: AdventureService {
         status: "pending_moderation"
       )
     )
+  }
+
+  func favoriteAdventure(id: String) async throws {
+    try await favoriteStore.favorite(id: MockFixtures.resolvedAdventureID(for: id))
+  }
+
+  func unfavoriteAdventure(id: String) async throws {
+    try await favoriteStore.unfavorite(id: MockFixtures.resolvedAdventureID(for: id))
   }
 }
 
@@ -340,6 +443,22 @@ struct RemoteAdventureService: AdventureService {
       body: payload,
       requiresAuth: true
     )
+  }
+
+  func favoriteAdventure(id: String) async throws {
+    try await client.postNoContent(
+      pathComponents: ["adventures", id, "favorite"],
+      requiresAuth: true
+    )
+    FavoriteStateChange.post(adventureID: id, isFavorited: true)
+  }
+
+  func unfavoriteAdventure(id: String) async throws {
+    try await client.deleteNoContent(
+      pathComponents: ["adventures", id, "favorite"],
+      requiresAuth: true
+    )
+    FavoriteStateChange.post(adventureID: id, isFavorited: false)
   }
 
   private func uploadPhoto(

--- a/App/Services/ProfileService.swift
+++ b/App/Services/ProfileService.swift
@@ -32,11 +32,23 @@ protocol ProfileService {
     offset: Int
   ) async throws -> ProfileResponse
 
+  func getProfileFavorites(
+    handle: String,
+    limit: Int,
+    offset: Int
+  ) async throws -> ProfileFavoritesResponse
+
   func getMyProfile() async throws -> MeProfileResponse
   func updateMyProfile(request: MeProfileUpdateRequest) async throws -> MeProfileResponse
 }
 
 struct FixtureProfileService: ProfileService {
+  let favoriteStore: FavoriteFixtureStore
+
+  init(favoriteStore: FavoriteFixtureStore = FavoriteFixtureStore.fromEnvironment()) {
+    self.favoriteStore = favoriteStore
+  }
+
   func getProfile(
     handle: String,
     limit: Int,
@@ -53,8 +65,29 @@ struct FixtureProfileService: ProfileService {
     )
     return ProfileResponse(
       profile: profile,
-      adventures: adventures,
+      adventures: await applyFavoriteState(to: adventures),
       paging: Paging(limit: limit, offset: offset, returned: adventures.count)
+    )
+  }
+
+  func getProfileFavorites(
+    handle: String,
+    limit: Int,
+    offset: Int
+  ) async throws -> ProfileFavoritesResponse {
+    guard handle == MockFixtures.profile.handle else {
+      throw APIError.server(statusCode: 403, message: "Favorites are only available for the signed-in viewer.")
+    }
+
+    let favoriteIDs = await favoriteStore.favoriteIDs()
+    let favorites = MockFixtures.feedItems
+      .filter { favoriteIDs.contains($0.id) }
+      .map { $0.applyingFavoriteState(true) }
+    let pagedItems = Array(favorites.dropFirst(offset).prefix(limit))
+
+    return ProfileFavoritesResponse(
+      items: pagedItems,
+      paging: Paging(limit: limit, offset: offset, returned: pagedItems.count)
     )
   }
 
@@ -83,6 +116,13 @@ struct FixtureProfileService: ProfileService {
       )
     )
   }
+
+  private func applyFavoriteState(to adventures: [AdventureCard]) async -> [AdventureCard] {
+    let favoriteIDs = await favoriteStore.favoriteIDs()
+    return adventures.map { adventure in
+      adventure.applyingFavoriteState(favoriteIDs.contains(adventure.id))
+    }
+  }
 }
 
 struct RemoteProfileService: ProfileService {
@@ -95,6 +135,21 @@ struct RemoteProfileService: ProfileService {
   ) async throws -> ProfileResponse {
     try await client.get(
       pathComponents: ["profiles", handle],
+      queryItems: [
+        URLQueryItem(name: "limit", value: String(limit)),
+        URLQueryItem(name: "offset", value: String(offset))
+      ],
+      requiresAuth: true
+    )
+  }
+
+  func getProfileFavorites(
+    handle: String,
+    limit: Int,
+    offset: Int
+  ) async throws -> ProfileFavoritesResponse {
+    try await client.get(
+      pathComponents: ["profiles", handle, "favorites"],
       queryItems: [
         URLQueryItem(name: "limit", value: String(limit)),
         URLQueryItem(name: "offset", value: String(offset))

--- a/Docs/manual-qa-results.md
+++ b/Docs/manual-qa-results.md
@@ -10,6 +10,7 @@ Keep one entry per feature or slice, and update the notes as verification progre
 | --- | --- | --- | --- | --- | --- | --- |
 | 2026-04-19 | sidekicks-profile-discovery | `main` | `manual QA` | Add/remove sidekicks, sidekicks list, search for users, profile cards for sidekicks | Pass | Sidekicks functionality completely done. |
 | 2026-04-25 | discover-tab | `7cf2fa1dc474ed882903206684d7ba51e3ef5497` | `manual QA` | All features of the Discover tab | Pass with bugs | Several minor cosmetic bugs have been logged. |
+| 2026-04-28 | Favorites | `codex/favorites-ios-slice` | `manual QA` | All Favorites surfaces and the User Profile Shared/Favorites toggle | Pass | Testing complete. |
 
 ## Recommended Notes
 

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -206,7 +206,8 @@ final class APIClientTests: XCTestCase {
               "commentCount": 3,
               "ratingCount": 2,
               "averageRating": 4.5
-            }
+            },
+            "isFavorited": false
           }
         ],
         "paging": {
@@ -221,6 +222,156 @@ final class APIClientTests: XCTestCase {
     let response = try JSONDecoder().decode(FeedResponse.self, from: payload)
 
     XCTAssertEqual(response.items.first?.placeLabel, "Hidden Falls Trailhead")
+  }
+
+  func testFeedResponseDecodesFavoriteStateFromServerPayload() throws {
+    let payload = Data(
+      #"""
+      {
+        "items": [
+          {
+            "id": "adventure-1",
+            "title": "Hidden Falls",
+            "description": "Bring water and wear good shoes.",
+            "categorySlug": "water_spots",
+            "visibility": "public",
+            "createdAt": "2026-03-01T00:00:00.000Z",
+            "publishedAt": "2026-03-02T00:00:00.000Z",
+            "location": {
+              "latitude": 34.12,
+              "longitude": -118.45
+            },
+            "placeLabel": "Hidden Falls Trailhead",
+            "author": {
+              "handle": "jacksanfil",
+              "displayName": "Jack",
+              "homeCity": "Los Angeles",
+              "homeRegion": "CA"
+            },
+            "primaryMedia": {
+              "id": "media-1",
+              "storageKey": "adventures/media-1.jpg"
+            },
+            "stats": {
+              "favoriteCount": 8,
+              "commentCount": 3,
+              "ratingCount": 2,
+              "averageRating": 4.5
+            },
+            "isFavorited": true
+          }
+        ],
+        "paging": {
+          "limit": 20,
+          "offset": 0,
+          "returned": 1
+        }
+      }
+      """#.utf8
+    )
+
+    let response = try JSONDecoder().decode(FeedResponse.self, from: payload)
+
+    XCTAssertEqual(response.items.first?.isFavorited, true)
+  }
+
+  func testAdventureDetailResponseDecodesFavoriteStateFromServerPayload() throws {
+    let payload = Data(
+      #"""
+      {
+        "item": {
+          "id": "adventure-1",
+          "title": "Hidden Falls",
+          "description": "Bring water and wear good shoes.",
+          "categorySlug": "water_spots",
+          "visibility": "public",
+          "createdAt": "2026-03-01T00:00:00.000Z",
+          "publishedAt": "2026-03-02T00:00:00.000Z",
+          "location": {
+            "latitude": 34.12,
+            "longitude": -118.45
+          },
+          "author": {
+            "handle": "jacksanfil",
+            "displayName": "Jack",
+            "homeCity": "Los Angeles",
+            "homeRegion": "CA"
+          },
+          "primaryMedia": {
+            "id": "media-1",
+            "storageKey": "adventures/media-1.jpg"
+          },
+          "stats": {
+            "favoriteCount": 8,
+            "commentCount": 3,
+            "ratingCount": 2,
+            "averageRating": 4.5
+          },
+          "placeLabel": "Hidden Falls Trailhead",
+          "updatedAt": "2026-03-03T00:00:00.000Z",
+          "isFavorited": false
+        }
+      }
+      """#.utf8
+    )
+
+    let response = try JSONDecoder().decode(AdventureDetailResponse.self, from: payload)
+
+    XCTAssertEqual(response.item.isFavorited, false)
+  }
+
+  func testProfileFavoritesResponseDecodesItemsAndPaging() throws {
+    let payload = Data(
+      #"""
+      {
+        "items": [
+          {
+            "id": "adventure-1",
+            "title": "Hidden Falls",
+            "description": "Bring water and wear good shoes.",
+            "categorySlug": "water_spots",
+            "visibility": "public",
+            "createdAt": "2026-03-01T00:00:00.000Z",
+            "publishedAt": "2026-03-02T00:00:00.000Z",
+            "location": {
+              "latitude": 34.12,
+              "longitude": -118.45
+            },
+            "placeLabel": "Hidden Falls Trailhead",
+            "author": {
+              "handle": "jacksanfil",
+              "displayName": "Jack",
+              "homeCity": "Los Angeles",
+              "homeRegion": "CA"
+            },
+            "primaryMedia": {
+              "id": "media-1",
+              "storageKey": "adventures/media-1.jpg"
+            },
+            "stats": {
+              "favoriteCount": 8,
+              "commentCount": 3,
+              "ratingCount": 2,
+              "averageRating": 4.5
+            },
+            "isFavorited": true
+          }
+        ],
+        "paging": {
+          "limit": 10,
+          "offset": 0,
+          "returned": 1
+        }
+      }
+      """#.utf8
+    )
+
+    let response = try JSONDecoder().decode(ProfileFavoritesResponse.self, from: payload)
+
+    XCTAssertEqual(response.items.map(\.id), ["adventure-1"])
+    XCTAssertEqual(response.items.first?.isFavorited, true)
+    XCTAssertEqual(response.paging.limit, 10)
+    XCTAssertEqual(response.paging.returned, 1)
   }
 
   func testGetMediaReturnsFetchedPayloadAndParsesCacheHeaders() async throws {

--- a/Tests/AdventureServiceTests.swift
+++ b/Tests/AdventureServiceTests.swift
@@ -126,6 +126,68 @@ final class AdventureServiceTests: XCTestCase {
     XCTAssertEqual(payload.visibility, "sidekicks")
   }
 
+  func testFavoriteAdventurePostsToFavoriteEndpointWithoutResponseBody() async throws {
+    MockAdventureURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.httpMethod, "POST")
+      XCTAssertEqual(request.url?.path, "/api/adventures/adventure-1/favorite")
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 204,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+
+      return (response, Data())
+    }
+
+    let service = makeService(cache: makeCache())
+
+    try await service.favoriteAdventure(id: "adventure-1")
+  }
+
+  func testUnfavoriteAdventureDeletesFavoriteEndpointWithoutResponseBody() async throws {
+    MockAdventureURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.httpMethod, "DELETE")
+      XCTAssertEqual(request.url?.path, "/api/adventures/adventure-1/favorite")
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 204,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+
+      return (response, Data())
+    }
+
+    let service = makeService(cache: makeCache())
+
+    try await service.unfavoriteAdventure(id: "adventure-1")
+  }
+
+  func testFixtureFavoriteStateUpdatesFeedAndDetail() async throws {
+    let store = FavoriteFixtureStore(initialFavoriteIDs: [])
+    let service = FixtureAdventureService(favoriteStore: store)
+
+    let initialFeed = try await service.listFeed(query: FeedQuery(limit: 20, offset: 0)).items
+    XCTAssertEqual(initialFeed.first(where: { $0.id == MockFixtures.bluePoolID })?.isFavorited, false)
+
+    try await service.favoriteAdventure(id: MockFixtures.bluePoolID)
+
+    let favoriteFeed = try await service.listFeed(query: FeedQuery(limit: 20, offset: 0)).items
+    let favoriteDetail = try await service.getAdventure(id: MockFixtures.bluePoolID).item
+    XCTAssertEqual(favoriteFeed.first(where: { $0.id == MockFixtures.bluePoolID })?.isFavorited, true)
+    XCTAssertEqual(favoriteDetail.isFavorited, true)
+
+    try await service.unfavoriteAdventure(id: MockFixtures.bluePoolID)
+
+    let unfavoriteDetail = try await service.getAdventure(id: MockFixtures.bluePoolID).item
+    XCTAssertEqual(unfavoriteDetail.isFavorited, false)
+  }
+
   func testLoadMediaDataUsesFreshCacheWithoutRefetching() async throws {
     final class RequestCounter {
       var count = 0

--- a/Tests/AppAuthServiceTests.swift
+++ b/Tests/AppAuthServiceTests.swift
@@ -11,7 +11,7 @@ final class AppAuthServiceTests: XCTestCase {
   }
 
   func testGetStartedUsesSignUpWithDerivedUsername() async throws {
-    let expectedUsername = "new_1853b7412ac94d75cb23e033"
+    let expectedUsername = "new_f0030501023327437b06e5c6"
 
     CognitoMockURLProtocol.requestHandler = { request in
       XCTAssertEqual(request.value(forHTTPHeaderField: "X-Amz-Target"), "AWSCognitoIdentityProviderService.SignUp")
@@ -52,7 +52,7 @@ final class AppAuthServiceTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "X-Amz-Target"), "AWSCognitoIdentityProviderService.SignUp")
 
         let payload = try XCTUnwrap(Self.jsonPayload(from: request))
-        XCTAssertEqual(payload["Username"] as? String, "new_1853b7412ac94d75cb23e033")
+        XCTAssertEqual(payload["Username"] as? String, "new_f0030501023327437b06e5c6")
 
         return Self.errorResponse(
           request: request,
@@ -65,7 +65,7 @@ final class AppAuthServiceTests: XCTestCase {
 
         let payload = try XCTUnwrap(Self.jsonPayload(from: request))
         XCTAssertEqual(payload["ClientId"] as? String, "client-id")
-        XCTAssertEqual(payload["Username"] as? String, "new_1853b7412ac94d75cb23e033")
+        XCTAssertEqual(payload["Username"] as? String, "new_f0030501023327437b06e5c6")
 
         return Self.successResponse(
           request: request,
@@ -83,7 +83,7 @@ final class AppAuthServiceTests: XCTestCase {
     }
 
     XCTAssertEqual(challenge.kind, .signUp)
-    XCTAssertEqual(challenge.cognitoUsername, "new_1853b7412ac94d75cb23e033")
+    XCTAssertEqual(challenge.cognitoUsername, "new_f0030501023327437b06e5c6")
     XCTAssertEqual(challenge.email, "new@example.com")
     XCTAssertEqual(challenge.deliveryDestination, "ne•••@example.com")
     XCTAssertTrue(challenge.isResumed)
@@ -375,7 +375,7 @@ final class AppAuthServiceTests: XCTestCase {
   }
 
   private static func jsonPayload(from request: URLRequest) -> [String: Any]? {
-    guard let data = request.httpBody else {
+    guard let data = request.bodyData else {
       return nil
     }
 
@@ -461,4 +461,34 @@ private final class CognitoMockURLProtocol: URLProtocol {
   }
 
   override func stopLoading() {}
+}
+
+private extension URLRequest {
+  var bodyData: Data? {
+    if let httpBody {
+      return httpBody
+    }
+
+    guard let stream = httpBodyStream else {
+      return nil
+    }
+
+    stream.open()
+    defer { stream.close() }
+
+    let bufferSize = 1024
+    var data = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+      let read = stream.read(buffer, maxLength: bufferSize)
+      guard read > 0 else {
+        break
+      }
+      data.append(buffer, count: read)
+    }
+
+    return data.isEmpty ? nil : data
+  }
 }

--- a/Tests/AppSessionTests.swift
+++ b/Tests/AppSessionTests.swift
@@ -820,6 +820,10 @@ private final class ProfileServiceStub: ProfileService {
     ProfileResponse(profile: updatedProfile, adventures: [], paging: Paging(limit: limit, offset: offset, returned: 0))
   }
 
+  func getProfileFavorites(handle: String, limit: Int, offset: Int) async throws -> ProfileFavoritesResponse {
+    ProfileFavoritesResponse(items: [], paging: Paging(limit: limit, offset: offset, returned: 0))
+  }
+
   func getMyProfile() async throws -> MeProfileResponse {
     MeProfileResponse(profile: updatedProfile)
   }

--- a/Tests/DiscoverServiceTests.swift
+++ b/Tests/DiscoverServiceTests.swift
@@ -153,7 +153,8 @@ final class DiscoverServiceTests: XCTestCase {
               "commentCount": 3,
               "ratingCount": 4,
               "averageRating": 4.75
-            }
+            },
+            "isFavorited": true
           }
         ]
       }
@@ -204,7 +205,8 @@ final class DiscoverServiceTests: XCTestCase {
             "commentCount": 3,
             "ratingCount": 4,
             "averageRating": 4.75
-          }
+          },
+          "isFavorited": true
         }
       ],
       "paging": { "limit": 20, "offset": 0, "returned": 1 }

--- a/Tests/ProfileServiceTests.swift
+++ b/Tests/ProfileServiceTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import HiddenAdventures
 
 final class ProfileServiceTests: XCTestCase {
+  override func tearDown() {
+    ProfileMockURLProtocol.requestHandler = nil
+    super.tearDown()
+  }
+
   func testFixtureServiceReturnsViewerVisibleAdventuresForSelfAndSidekickProfiles() async throws {
     let service = FixtureProfileService()
 
@@ -36,4 +41,142 @@ final class ProfileServiceTests: XCTestCase {
     XCTAssertEqual(theoProfile.adventures.map(\.id), [MockFixtures.bluePoolID])
     XCTAssertTrue(theoProfile.adventures.allSatisfy { $0.visibility == .public })
   }
+
+  func testRemoteServiceFetchesProfileFavoritesWithPagingAndAuth() async throws {
+    ProfileMockURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.httpMethod, "GET")
+      XCTAssertEqual(request.url?.path, "/api/profiles/jordan/favorites")
+      XCTAssertEqual(request.url?.query, "limit=10&offset=20")
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+
+      return (
+        response,
+        Data(
+          #"""
+          {
+            "items": [
+              {
+                "id": "adventure-1",
+                "title": "Hidden Falls",
+                "description": "Bring water and wear good shoes.",
+                "categorySlug": "water_spots",
+                "visibility": "public",
+                "createdAt": "2026-03-01T00:00:00.000Z",
+                "publishedAt": "2026-03-02T00:00:00.000Z",
+                "location": {
+                  "latitude": 34.12,
+                  "longitude": -118.45
+                },
+                "placeLabel": "Hidden Falls Trailhead",
+                "author": {
+                  "handle": "jacksanfil",
+                  "displayName": "Jack",
+                  "homeCity": "Los Angeles",
+                  "homeRegion": "CA"
+                },
+                "primaryMedia": {
+                  "id": "media-1",
+                  "storageKey": "adventures/media-1.jpg"
+                },
+                "stats": {
+                  "favoriteCount": 8,
+                  "commentCount": 3,
+                  "ratingCount": 2,
+                  "averageRating": 4.5
+                },
+                "isFavorited": true
+              }
+            ],
+            "paging": {
+              "limit": 10,
+              "offset": 20,
+              "returned": 1
+            }
+          }
+          """#.utf8
+        )
+      )
+    }
+
+    let service = RemoteProfileService(client: Self.makeClient())
+
+    let response = try await service.getProfileFavorites(handle: "jordan", limit: 10, offset: 20)
+
+    XCTAssertEqual(response.items.map(\.id), ["adventure-1"])
+    XCTAssertEqual(response.items.first?.isFavorited, true)
+    XCTAssertEqual(response.paging.offset, 20)
+  }
+
+  func testFixtureServiceReturnsPopulatedAndEmptyFavoritesStates() async throws {
+    let populated = FixtureProfileService(
+      favoriteStore: FavoriteFixtureStore(initialFavoriteIDs: [MockFixtures.bluePoolID])
+    )
+
+    let populatedResponse = try await populated.getProfileFavorites(
+      handle: MockFixtures.profile.handle,
+      limit: 20,
+      offset: 0
+    )
+    XCTAssertEqual(populatedResponse.items.map(\.id), [MockFixtures.bluePoolID])
+    XCTAssertTrue(populatedResponse.items.allSatisfy(\.isFavorited))
+
+    let empty = FixtureProfileService(favoriteStore: FavoriteFixtureStore(initialFavoriteIDs: []))
+    let emptyResponse = try await empty.getProfileFavorites(
+      handle: MockFixtures.profile.handle,
+      limit: 20,
+      offset: 0
+    )
+    XCTAssertEqual(emptyResponse.items, [])
+  }
+
+  private static func makeClient() -> APIClient {
+    APIClient(
+      baseURL: URL(string: "https://example.com/api")!,
+      authTokenProvider: { "token" },
+      session: URLSession(configuration: makeConfiguration())
+    )
+  }
+
+  private static func makeConfiguration() -> URLSessionConfiguration {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [ProfileMockURLProtocol.self]
+    return configuration
+  }
+}
+
+private final class ProfileMockURLProtocol: URLProtocol {
+  static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let requestHandler = Self.requestHandler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+
+    do {
+      let (response, data) = try requestHandler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
 }

--- a/UITests/Base/HiddenAdventuresUITestCase.swift
+++ b/UITests/Base/HiddenAdventuresUITestCase.swift
@@ -3,6 +3,7 @@ import XCTest
 class HiddenAdventuresUITestCase: XCTestCase {
   let eagleID = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
   let bluePoolID = "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB"
+  let jordanHiddenRidgeID = "adventure-jordan-hidden-ridge"
 
   override func setUpWithError() throws {
     continueAfterFailure = false

--- a/UITests/Screens/DetailScreenUITests.swift
+++ b/UITests/Screens/DetailScreenUITests.swift
@@ -93,4 +93,37 @@ final class DetailScreenUITests: HiddenAdventuresUITestCase {
       screenshotDir: screenshotDir
     )
   }
+
+  func testDetail_favoriteButtonReflectsAndTogglesFavoriteState() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "detail-favorite-toggle")
+    let app = launchApp(
+      startScreen: "detail",
+      extraEnv: ["UITEST_DETAIL_ID": bluePoolID]
+    )
+
+    let favoriteButton = app.buttons["detail.favorite"]
+    assertExists(
+      favoriteButton,
+      name: "detail-favorite-button",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertValue(
+      favoriteButton,
+      equals: "not favorited",
+      name: "detail-favorite-button-initial-state",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+
+    favoriteButton.tap()
+
+    assertValue(
+      favoriteButton,
+      equals: "favorited",
+      name: "detail-favorite-button-toggled-state",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
 }

--- a/UITests/Screens/ExploreFeedScreenUITests.swift
+++ b/UITests/Screens/ExploreFeedScreenUITests.swift
@@ -88,6 +88,43 @@ final class ExploreFeedScreenUITests: HiddenAdventuresUITestCase {
     XCTAssertEqual(categoryChips.count, 8, "Expected exactly 8 category chips in Explore.")
   }
 
+  func testExploreFeed_bookmarkButtonReflectsAndTogglesFavoriteState() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "explore-feed-favorite-toggle")
+    let app = launchApp(startScreen: "explore-feed")
+
+    app.buttons["header.search"].tap()
+    let searchField = app.textFields["feed.searchField"]
+    assertExists(searchField, name: "feed-search-field-for-favorite", in: app, screenshotDir: screenshotDir)
+    searchField.tap()
+    searchField.typeText("Port")
+    app.buttons["feed.searchSuggestion.portland-oregon"].tap()
+
+    let favoriteButton = app.buttons["feed.card.favorite.\(jordanHiddenRidgeID)"]
+    assertExists(
+      favoriteButton,
+      name: "feed-favorite-button",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertValue(
+      favoriteButton,
+      equals: "not favorited",
+      name: "feed-favorite-button-initial-state",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+
+    favoriteButton.tap()
+
+    assertValue(
+      favoriteButton,
+      equals: "favorited",
+      name: "feed-favorite-button-toggled-state",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
+
   func testExploreFeed_returningFromDetailPreservesHomeTabChrome() throws {
     let screenshotDir = try preparedScreenshotDirectory(named: "explore-feed-detail-return")
     let app = launchApp(startScreen: "explore-feed")

--- a/UITests/Screens/ProfileScreenUITests.swift
+++ b/UITests/Screens/ProfileScreenUITests.swift
@@ -49,6 +49,92 @@ final class ProfileScreenUITests: HiddenAdventuresUITestCase {
     )
   }
 
+  func testProfile_viewerFavoritesShowsPopulatedCollection() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "profile-favorites-populated")
+    let app = launchApp(
+      startScreen: "explore-profile",
+      extraEnv: ["UITEST_PROFILE_FAVORITES": "populated"]
+    )
+
+    assertExists(
+      app.buttons["profile.segment.favorites"],
+      name: "profile-favorites-segment",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    app.buttons["profile.segment.favorites"].tap()
+
+    assertExists(
+      app.staticTexts["profile.favoriteAdventuresHeading"],
+      name: "profile-favorite-adventures-heading",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertExists(
+      app.buttons["feed.card.\(bluePoolID)"],
+      name: "profile-favorite-adventure-card",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertNotExists(
+      app.staticTexts["profile.favorites.empty"],
+      name: "profile-favorites-empty-hidden",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
+
+  func testProfile_viewerFavoritesShowsEmptyState() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "profile-favorites-empty")
+    let app = launchApp(
+      startScreen: "explore-profile",
+      extraEnv: ["UITEST_PROFILE_FAVORITES": "empty"]
+    )
+
+    assertExists(
+      app.buttons["profile.segment.favorites"],
+      name: "profile-favorites-segment-empty",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    app.buttons["profile.segment.favorites"].tap()
+
+    assertExists(
+      app.staticTexts["profile.favorites.empty"],
+      name: "profile-favorites-empty-state",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
+
+  func testProfile_otherProfileDoesNotShowFavoritesSegment() throws {
+    let screenshotDir = try preparedScreenshotDirectory(named: "profile-favorites-hidden-other-user")
+    let app = launchApp(startScreen: "explore-profile")
+
+    app.buttons["profile.sidekicksCard"].tap()
+    let rowButton = app.buttons["sidekicks.row.sarahc"]
+    assertHittable(
+      rowButton,
+      name: "sidekicks-row-open-sarah-for-favorites-hidden",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    rowButton.tap()
+
+    assertExists(
+      app.buttons["profile.back"],
+      name: "other-profile-loaded",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+    assertNotExists(
+      app.buttons["profile.segment.favorites"],
+      name: "other-profile-favorites-segment-hidden",
+      in: app,
+      screenshotDir: screenshotDir
+    )
+  }
+
   func testSidekicks_supportsTabsSearchAndActions() throws {
     let screenshotDir = try preparedScreenshotDirectory(named: "profile-sidekicks-interactions")
     let app = launchApp(startScreen: "explore-profile")


### PR DESCRIPTION
## Summary
- Add `isFavorited` decoding and favorite/unfavorite service calls for adventures.
- Wire feed and detail bookmark controls to real optimistic mutations with shared favorite-state updates.
- Add a viewer-only profile Favorites segment with populated and empty states, while preserving authored adventures and existing navigation.
- Extend fixture data and test coverage for decoding, services, and UI behavior.

## Testing
- Full iOS scheme test run passed locally.
- Added and validated unit coverage for model decoding, favorite mutations, and profile favorites fetches.
- Added UI coverage for feed, detail, and profile favorites states and toggle behavior.